### PR TITLE
Allow campaign creation without instances

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -6085,28 +6085,22 @@ HTML_APP = '''<!DOCTYPE html>
                 return;
             }
             
-            // Get selected instances
-            const selectedInstances = [];
-            document.querySelectorAll('#campaignInstancesList input[type="checkbox"]:checked').forEach(checkbox => {
-                selectedInstances.push(checkbox.value);
-            });
-            
-            if (selectedInstances.length === 0) {
-                alert('❌ Selecione pelo menos uma instância!');
-                return;
-            }
-            
+            const selectedInstances = Array.from(document.querySelectorAll('#campaignInstancesList input[type="checkbox"]:checked')).map(checkbox => checkbox.value);
+
             try {
                 const response = await fetch(`${WHATSFLOW_API_URL}/api/campaigns`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
                     },
-                    body: JSON.stringify({
+                    body: JSON.stringify(selectedInstances.length > 0 ? {
                         name: name,
                         description: description,
                         instances: selectedInstances,
                         status: 'active'
+                    } : {
+                        name: name,
+                        description: description
                     })
                 });
                 


### PR DESCRIPTION
## Summary
- Make instance selection optional when creating campaigns
- Post only name and description if no instances are chosen

## Testing
- `python -m py_compile whatsflow-real.py`
- `python campaign_test.py` *(fails: FileNotFoundError / connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c4693adb6c832fa749c973019a930b