### PR TITLE
feat: send media via generic mediaUrl

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -7650,29 +7650,34 @@ class MessageScheduler:
     def _send_message_to_group(self, instance_id, group_id, message_text, message_type, media_url):
         """Send message to group via Baileys API"""
         try:
-            payload = {
-                'to': group_id,
-                'message': message_text or '',
-                'type': message_type
-            }
-            
-            # Add media URL for non-text messages
-            if message_type != 'text' and media_url:
-                if message_type == 'image':
-                    payload['imageUrl'] = media_url
-                elif message_type == 'audio':
-                    payload['audioUrl'] = media_url  
-                elif message_type == 'video':
-                    payload['videoUrl'] = media_url
-            
+            if message_type == 'text':
+                payload = {
+                    'to': group_id,
+                    'type': 'text',
+                    'message': message_text or ''
+                }
+            else:
+                payload = {
+                    'to': group_id,
+                    'type': message_type,
+                    'mediaUrl': media_url,
+                }
+                if message_text:
+                    payload['caption'] = message_text
+
             response = requests.post(
                 f"{self.api_base_url}/send/{instance_id}",
                 json=payload,
                 timeout=30
             )
-            
+
+            if response.status_code != 200:
+                logger.error(
+                    f"Baileys send failed ({response.status_code}): {response.text}"
+                )
+
             return response.status_code == 200
-            
+
         except Exception as e:
             print(f"❌ Erro ao enviar via Baileys: {e}")
             return False


### PR DESCRIPTION
## Summary
- streamline media sending by always using `mediaUrl` and `caption`
- accept generic media types in Baileys service
- log Baileys errors with response body for easier debugging

## Testing
- `python -m py_compile whatsflow-real.py`
- `node --check baileys_service/server.js`
- `npm test` *(fails: Missing script: "test")*
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68c4c117989c832fa1d684ee906b2e6d