### PR TITLE
feat: support media urls for send endpoint

### DIFF
--- a/baileys_service/package-lock.json
+++ b/baileys_service/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@whiskeysockets/baileys": "^6.7.0",
+        "axios": "^1.12.1",
         "cors": "^2.8.5",
         "express": "^4.18.2",
         "node-fetch": "^2.6.7",

--- a/baileys_service/package.json
+++ b/baileys_service/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "dependencies": {
     "@whiskeysockets/baileys": "^6.7.0",
+    "axios": "^1.12.1",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
## Summary
- add axios dependency and import in Baileys service
- allow /send/:instanceId to send images, audio and video via URLs and retain legacy base64 images

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c4c116f5f0832f84305b94af35cf6b