### PR TITLE
feat: auto-detect Baileys service

### DIFF
--- a/whatsflow-professional.py
+++ b/whatsflow-professional.py
@@ -16,6 +16,7 @@ import time
 import signal
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import urllib.parse
+import urllib.request
 import logging
 from typing import Set, Dict, Any
 
@@ -31,8 +32,37 @@ except ImportError:
 # Configurações
 DB_FILE = "whatsflow.db"
 PORT = 8889
-API_BASE_URL = os.environ.get("API_BASE_URL", "http://localhost:3002")
 WEBSOCKET_PORT = 8890
+
+# Try to discover a reachable Baileys service. The environment variable takes
+# precedence, but we also try common local addresses.
+DEFAULT_BAILEYS_URLS = [
+    os.environ.get("API_BASE_URL"),
+    "http://78.46.250.112:3002",
+    "http://127.0.0.1:3002",
+    "http://localhost:3002",
+]
+
+
+def resolve_baileys_url() -> str:
+    """Return the first reachable Baileys service URL."""
+    for url in [u for u in DEFAULT_BAILEYS_URLS if u]:
+        try:
+            with urllib.request.urlopen(f"{url}/health", timeout=3) as response:
+                if response.status == 200:
+                    print(f"✅ Baileys service disponível em {url}")
+                    return url
+                else:
+                    print(
+                        f"⚠️ Baileys service respondeu com status {response.status} ({url}/health)"
+                    )
+        except Exception as e:
+            print(f"⚠️ Falha ao acessar Baileys em {url}/health: {e}")
+    print("❌ Baileys service não acessível em nenhuma URL. Usando http://localhost:3002")
+    return "http://localhost:3002"
+
+
+API_BASE_URL = resolve_baileys_url()
 
 # WebSocket clients management
 websocket_clients: Set[websockets.WebSocketServerProtocol] = set()


### PR DESCRIPTION
## Summary
- auto-detect Baileys service URL with fallback to common addresses
- avoid hard failure when configured Baileys host is unreachable

## Testing
- `python -m py_compile whatsflow-real.py whatsflow-professional.py`


------
https://chatgpt.com/codex/tasks/task_e_68c570c54568832f8fb5ebaf5f546e39