### PR TITLE
Remove stray codex marker from Baileys URL section

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -40,10 +40,8 @@ DB_FILE = "whatsflow.db"
 PORT = 8889
 WEBSOCKET_PORT = 8890
 
- codex/corrigir-erro-de-conexao-com-baileys-wjafpj
 # Candidate URLs for the Baileys service. We try to auto-discover the machine's
 # public IP so the script works even when the server address changes.
-
 
 def guess_public_baileys_url() -> Optional[str]:
     """Return Baileys URL using the machine's public IP if available."""


### PR DESCRIPTION
## Summary
- remove leftover codex marker and clean up Baileys URL discovery block

## Testing
- `python -m py_compile whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c58024d48c832f812b1676d365b5e9