### PR TITLE
Use context managers for selected DB reads

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -6852,23 +6852,23 @@ else:
 
 
 def add_sample_data():
-    conn = sqlite3.connect(DB_FILE)
-    cursor = conn.cursor()
-    
-    cursor.execute("SELECT COUNT(*) FROM instances")
-    if cursor.fetchone()[0] > 0:
-        conn.close()
-        return
-    
-    current_time = datetime.now(timezone.utc).isoformat()
-    
-    # Sample instance
-    instance_id = str(uuid.uuid4())
-    cursor.execute("INSERT INTO instances (id, name, contacts_count, messages_today, created_at) VALUES (?, ?, ?, ?, ?)",
-                  (instance_id, "WhatsApp Principal", 0, 0, current_time))
-    
-    conn.commit()
-    conn.close()
+    with sqlite3.connect(DB_FILE, timeout=30) as conn:
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT COUNT(*) FROM instances")
+        if cursor.fetchone()[0] > 0:
+            return
+
+        current_time = datetime.now(timezone.utc).isoformat()
+
+        # Sample instance
+        instance_id = str(uuid.uuid4())
+        cursor.execute(
+            "INSERT INTO instances (id, name, contacts_count, messages_today, created_at) VALUES (?, ?, ?, ?, ?)",
+            (instance_id, "WhatsApp Principal", 0, 0, current_time),
+        )
+
+        conn.commit()
 
 # Baileys Service Manager
 class BaileysManager:
@@ -8008,47 +8008,43 @@ class WhatsFlowRealHandler(BaseHTTPRequestHandler):
     
     def handle_get_instances(self):
         try:
-            conn = sqlite3.connect(DB_FILE)
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute("SELECT * FROM instances ORDER BY created_at DESC")
-            instances = [dict(row) for row in cursor.fetchall()]
-            conn.close()
+            with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.cursor()
+                cursor.execute("SELECT * FROM instances ORDER BY created_at DESC")
+                instances = [dict(row) for row in cursor.fetchall()]
             self.send_json_response(instances)
         except Exception as e:
             self.send_json_response({"error": str(e)}, 500)
-    
+
     def handle_get_stats(self):
         try:
-            conn = sqlite3.connect(DB_FILE)
-            cursor = conn.cursor()
-            
-            cursor.execute("SELECT COUNT(*) FROM contacts")
-            contacts_count = cursor.fetchone()[0]
-            
-            cursor.execute("SELECT COUNT(*) FROM messages")
-            messages_count = cursor.fetchone()[0]
-            
-            conn.close()
-            
+            with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                cursor = conn.cursor()
+
+                cursor.execute("SELECT COUNT(*) FROM contacts")
+                contacts_count = cursor.fetchone()[0]
+
+                cursor.execute("SELECT COUNT(*) FROM messages")
+                messages_count = cursor.fetchone()[0]
+
             stats = {
                 "contacts_count": contacts_count,
                 "conversations_count": contacts_count,
                 "messages_count": messages_count
             }
-            
+
             self.send_json_response(stats)
         except Exception as e:
             self.send_json_response({"error": str(e)}, 500)
-    
+
     def handle_get_messages(self):
         try:
-            conn = sqlite3.connect(DB_FILE)
-            conn.row_factory = sqlite3.Row
-            cursor = conn.cursor()
-            cursor.execute("SELECT * FROM messages ORDER BY created_at DESC LIMIT 50")
-            messages = [dict(row) for row in cursor.fetchall()]
-            conn.close()
+            with sqlite3.connect(DB_FILE, timeout=30) as conn:
+                conn.row_factory = sqlite3.Row
+                cursor = conn.cursor()
+                cursor.execute("SELECT * FROM messages ORDER BY created_at DESC LIMIT 50")
+                messages = [dict(row) for row in cursor.fetchall()]
             self.send_json_response(messages)
         except Exception as e:
             self.send_json_response({"error": str(e)}, 500)


### PR DESCRIPTION
## Summary
- ensure add_sample_data closes connections automatically
- handle instance, stats and message fetches with sqlite context managers

## Testing
- `python -m py_compile whatsflow-real.py`


------
https://chatgpt.com/codex/tasks/task_e_68c583577b80832f96b2c13fd1855a69