### PR TITLE
Remove stray placeholder line in message sending

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -7775,8 +7775,6 @@ class MessageScheduler:
                         json=payload,
                         timeout=(10, 180),
                     )
-update-timeout-handling-in-_send_message_to_group
-
 
                     if response.status_code != 200:
                         logger.error(


### PR DESCRIPTION
## Summary
- clean up `_send_message_to_group` by removing leftover placeholder text so the try/except structure is valid

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5a8320e8c832fa41a0e8c17717c1c