### PR TITLE
Fix SyntaxError in message sending

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -7775,9 +7775,7 @@ class MessageScheduler:
                         json=payload,
                         timeout=(10, 180),
                     )
-update-timeout-handling-in-_send_message_to_group
-
-
+                    
                     if response.status_code != 200:
                         logger.error(
                             f"Baileys send failed ({response.status_code}): {response.text}"


### PR DESCRIPTION
## Summary
- remove stray debug line that caused SyntaxError in `_send_message_to_group`
- ensure response handling executes within try block

## Testing
- `python3 -m py_compile whatsflow-real.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ace5d920832f8eab0d451053b0a5