### PR TITLE
Log message type before sending Baileys messages

### DIFF
--- a/whatsflow-real.py
+++ b/whatsflow-real.py
@@ -7770,6 +7770,15 @@ class MessageScheduler:
 
             for attempt in range(3):
                 try:
+                    log_details = f"message_type={message_type}, media_url={media_url}"
+                    if message_type == 'text':
+                        logger.info(
+                            f"📤 Enviando mensagem de texto ao grupo {group_id} ({log_details})"
+                        )
+                    else:
+                        logger.info(
+                            f"📤 Enviando mensagem de mídia ao grupo {group_id} ({log_details})"
+                        )
                     response = requests.post(
                         f"{self.api_base_url}/send/{instance_id}",
                         json=payload,


### PR DESCRIPTION
## Summary
- log `message_type` and `media_url` before calling Baileys API so text and media sends are clear

## Testing
- `python -m py_compile whatsflow-real.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5b204fc80832fbe50256c00981036